### PR TITLE
Update config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
   "startup": "system",
   "arch": ["aarch64", "amd64", "armv7"],
   "boot": "auto",
+  "init": "false",
   "map": ["config:rw","ssl"],
   "ports": {
     "80/tcp": 8621


### PR DESCRIPTION
Add "init": "false", to fix start issue 

"s6-overlay-suexec: fatal: can only run as pid 1"

when using V3 S6: https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/